### PR TITLE
Add Tailscale integration and systemd service installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,306 @@
+# HTTP Dispatcher Installation Guide
+
+## Quick Start
+
+### One-Liner Installation
+
+**Install as Coordinator (with monitoring):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- coordinator
+```
+
+**Install as Agent:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent --coordinator-url http://coordinator-ip:8000
+```
+
+**With custom options:**
+```bash
+# Coordinator on custom port
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- coordinator --port 9000
+
+# Agent with custom ID
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent --coordinator-url http://coordinator:8000 --agent-id my-agent-01
+```
+
+## Local Installation
+
+If you have the repository locally:
+
+```bash
+# Navigate to the project directory
+cd http-dispatcher
+
+# Install as coordinator
+sudo bash install.sh coordinator
+
+# Install as agent
+sudo bash install.sh agent --coordinator-url http://coordinator-ip:8000
+```
+
+## What Gets Installed
+
+### Files and Directories
+- `/opt/http-dispatcher/` - Main installation directory
+  - `bin/main.py` - Main application script
+  - `lib/src/` - Application source code
+  - `monitoring/` - Monitoring configuration (coordinator only)
+  - `etc/` - Configuration files
+
+### Systemd Services
+- `http-dispatcher-coordinator.service` - Coordinator service
+- `http-dispatcher-agent.service` - Agent service
+- `http-dispatcher-monitoring.service` - Monitoring stack (coordinator only)
+
+### Management Command
+- `/usr/local/bin/http-dispatcher` - Service management script
+
+## Service Management
+
+### Using the Management Script
+
+```bash
+# Check status
+http-dispatcher coordinator status
+http-dispatcher agent status
+http-dispatcher monitoring status
+
+# View logs (follow mode)
+http-dispatcher coordinator logs
+http-dispatcher agent logs
+
+# Control services
+http-dispatcher coordinator start
+http-dispatcher coordinator stop
+http-dispatcher coordinator restart
+
+# Enable/disable auto-start
+http-dispatcher coordinator enable
+http-dispatcher coordinator disable
+```
+
+### Using systemd Directly
+
+```bash
+# Status
+sudo systemctl status http-dispatcher-coordinator
+sudo systemctl status http-dispatcher-agent
+sudo systemctl status http-dispatcher-monitoring
+
+# Control
+sudo systemctl start http-dispatcher-coordinator
+sudo systemctl stop http-dispatcher-coordinator
+sudo systemctl restart http-dispatcher-coordinator
+
+# Enable/disable
+sudo systemctl enable http-dispatcher-coordinator
+sudo systemctl disable http-dispatcher-coordinator
+
+# View logs
+sudo journalctl -u http-dispatcher-coordinator -f
+sudo journalctl -u http-dispatcher-agent -f
+```
+
+## Configuration
+
+### Coordinator Configuration
+
+Edit the systemd service file to change coordinator settings:
+
+```bash
+sudo systemctl edit http-dispatcher-coordinator
+```
+
+Or edit directly:
+```bash
+sudo nano /etc/systemd/system/http-dispatcher-coordinator.service
+```
+
+Change the `ExecStart` line to modify host/port:
+```ini
+ExecStart=/usr/bin/python3 /opt/http-dispatcher/bin/main.py --mode coordinator --host 0.0.0.0 --port 8000
+```
+
+Then reload and restart:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart http-dispatcher-coordinator
+```
+
+### Agent Configuration
+
+Edit the systemd service file:
+```bash
+sudo systemctl edit http-dispatcher-agent
+```
+
+Or edit directly:
+```bash
+sudo nano /etc/systemd/system/http-dispatcher-agent.service
+```
+
+Change environment variables:
+```ini
+Environment="DISPATCHER_COORDINATOR_URL=http://coordinator-ip:8000"
+Environment="DISPATCHER_AGENT_ID=my-agent-id"
+```
+
+Then reload and restart:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart http-dispatcher-agent
+```
+
+## Monitoring Setup
+
+The monitoring stack is automatically installed and started when installing as coordinator. It includes:
+
+- **Prometheus** - Metrics collection (port 9090)
+- **Grafana** - Dashboards (port 3000, default login: admin/admin)
+- **Node Exporter** - System metrics (port 9100)
+- **Alertmanager** - Alert handling (port 9093)
+
+### Access Monitoring
+
+- Grafana: http://localhost:3000 (admin/admin)
+- Prometheus: http://localhost:9090
+- Metrics endpoint: http://localhost:8000/metrics
+
+### Prometheus Configuration
+
+If your coordinator is not accessible via `host.docker.internal`, edit the Prometheus config:
+
+```bash
+sudo nano /opt/http-dispatcher/monitoring/prometheus.yml
+```
+
+Update the target to use your coordinator's IP:
+```yaml
+- job_name: 'http-dispatcher'
+  static_configs:
+    - targets: ['YOUR_COORDINATOR_IP:8000']
+```
+
+Then restart monitoring:
+```bash
+http-dispatcher monitoring restart
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+1. Check service status:
+   ```bash
+   sudo systemctl status http-dispatcher-coordinator
+   ```
+
+2. Check logs:
+   ```bash
+   sudo journalctl -u http-dispatcher-coordinator -n 50
+   ```
+
+3. Verify Python installation:
+   ```bash
+   python3 --version
+   which python3
+   ```
+
+4. Check file permissions:
+   ```bash
+   ls -la /opt/http-dispatcher
+   sudo chown -R http-dispatcher:http-dispatcher /opt/http-dispatcher
+   ```
+
+### Agent Can't Connect to Coordinator
+
+1. Verify coordinator is running:
+   ```bash
+   curl http://coordinator-ip:8000/api/stats
+   ```
+
+2. Check network connectivity:
+   ```bash
+   ping coordinator-ip
+   telnet coordinator-ip 8000
+   ```
+
+3. Check agent logs:
+   ```bash
+   http-dispatcher agent logs
+   ```
+
+4. Verify coordinator URL in agent service:
+   ```bash
+   sudo systemctl show http-dispatcher-agent | grep COORDINATOR
+   ```
+
+### Monitoring Not Working
+
+1. Check if Docker is running:
+   ```bash
+   sudo systemctl status docker
+   ```
+
+2. Check monitoring service:
+   ```bash
+   http-dispatcher monitoring status
+   ```
+
+3. Check Docker containers:
+   ```bash
+   docker ps
+   docker logs prometheus
+   docker logs grafana
+   ```
+
+4. Verify Prometheus can reach coordinator:
+   ```bash
+   docker exec prometheus wget -qO- http://host.docker.internal:8000/metrics
+   ```
+
+## Uninstallation
+
+To remove HTTP Dispatcher:
+
+```bash
+# Stop and disable services
+sudo systemctl stop http-dispatcher-coordinator
+sudo systemctl stop http-dispatcher-agent
+sudo systemctl stop http-dispatcher-monitoring
+sudo systemctl disable http-dispatcher-coordinator
+sudo systemctl disable http-dispatcher-agent
+sudo systemctl disable http-dispatcher-monitoring
+
+# Remove service files
+sudo rm /etc/systemd/system/http-dispatcher-*.service
+sudo systemctl daemon-reload
+
+# Remove installation
+sudo rm -rf /opt/http-dispatcher
+sudo rm /usr/local/bin/http-dispatcher
+
+# Remove service user (optional)
+sudo userdel http-dispatcher
+```
+
+## Upgrading
+
+To upgrade to a new version:
+
+```bash
+# Stop services
+sudo systemctl stop http-dispatcher-coordinator
+sudo systemctl stop http-dispatcher-agent
+
+# Backup current installation
+sudo cp -r /opt/http-dispatcher /opt/http-dispatcher.backup
+
+# Run installation script again (it will update files)
+sudo bash install.sh coordinator
+
+# Restart services
+sudo systemctl start http-dispatcher-coordinator
+sudo systemctl start http-dispatcher-agent
+```
+

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,138 @@
+# HTTP Dispatcher - Quick Start Guide
+
+## 🚀 One-Liner Installation
+
+### Coordinator (Server)
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- coordinator
+```
+
+### Agent (Client)
+
+**With Tailscale (Recommended - Auto-detects coordinator!):**
+```bash
+# Just run this - coordinator is auto-detected!
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent
+```
+
+**Without Tailscale:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent --coordinator-url http://YOUR_COORDINATOR_IP:8000
+```
+
+## 🎯 Tailscale Makes It Easy!
+
+If you use **Tailscale**, the installer automatically:
+- Finds your coordinator (no need to specify URL)
+- Configures secure networking
+- Sets up monitoring connections
+- Uses friendly hostnames instead of IPs
+
+Just install and it works! 🎉
+
+## 📋 What You Get
+
+✅ **Automatic Service Management** - No more tmux! Services run as systemd units  
+✅ **Auto-Restart** - Services automatically restart on failure or reboot  
+✅ **Integrated Monitoring** - Prometheus + Grafana automatically set up (coordinator only)  
+✅ **Easy Management** - Simple commands to control everything  
+
+## 🎮 Quick Commands
+
+```bash
+# Check status
+http-dispatcher coordinator status
+http-dispatcher agent status
+
+# View logs
+http-dispatcher coordinator logs
+http-dispatcher agent logs
+
+# Restart services
+http-dispatcher coordinator restart
+http-dispatcher agent restart
+
+# Stop/Start
+http-dispatcher coordinator stop
+http-dispatcher coordinator start
+```
+
+## 🌐 Access Points (Coordinator)
+
+After installation, access:
+- **API**: http://localhost:8000
+- **Metrics**: http://localhost:8000/metrics
+- **Grafana**: http://localhost:3000 (admin/admin)
+- **Prometheus**: http://localhost:9090
+
+## 🔧 Configuration
+
+### Change Coordinator Port
+```bash
+sudo systemctl edit http-dispatcher-coordinator
+```
+Add:
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/bin/python3 /opt/http-dispatcher/bin/main.py --mode coordinator --host 0.0.0.0 --port 9000
+```
+Then:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart http-dispatcher-coordinator
+```
+
+### Change Agent Coordinator URL
+```bash
+sudo systemctl edit http-dispatcher-agent
+```
+Add:
+```ini
+[Service]
+Environment="DISPATCHER_COORDINATOR_URL=http://new-coordinator:8000"
+```
+Then:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart http-dispatcher-agent
+```
+
+## 🐛 Troubleshooting
+
+### Service won't start?
+```bash
+# Check status
+sudo systemctl status http-dispatcher-coordinator
+
+# View logs
+sudo journalctl -u http-dispatcher-coordinator -n 50
+```
+
+### Agent can't connect?
+```bash
+# Test coordinator
+curl http://coordinator-ip:8000/api/stats
+
+# Check agent logs
+http-dispatcher agent logs
+```
+
+### Monitoring not working?
+```bash
+# Check Docker
+sudo systemctl status docker
+
+# Check monitoring service
+http-dispatcher monitoring status
+
+# View container logs
+docker logs prometheus
+docker logs grafana
+```
+
+## 📚 More Information
+
+- Full installation guide: [INSTALL.md](INSTALL.md)
+- Complete documentation: [README.md](README.md)
+

--- a/README.md
+++ b/README.md
@@ -15,13 +15,94 @@ A distributed HTTP request system with IPv6 support, featuring agent-based reque
 - **Request History**: Tracks all executed requests with metadata
 - **Agent Reconnection**: Automatic reconnection with exponential backoff when coordinator restarts
 
-## Installation
+## Quick Installation
+
+### 🚀 One-Liner Installation
+
+**Install as Coordinator:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- coordinator
+```
+
+**Install as Agent (with Tailscale auto-detection):**
+```bash
+# If using Tailscale, coordinator is auto-detected!
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent
+
+# Or specify coordinator manually
+curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent --coordinator-url http://coordinator-hostname:8000
+```
+
+**Install from Local Source:**
+```bash
+# Clone or download the repository first
+git clone https://github.com/your-repo/http-dispatcher.git
+cd http-dispatcher
+
+# Run installation script
+sudo bash install.sh coordinator
+# or (with Tailscale auto-detection)
+sudo bash install.sh agent
+```
+
+### 🎯 Tailscale Integration
+
+If you're using **Tailscale** (recommended!), the installer automatically:
+- ✅ **Auto-detects coordinator** - No need to specify `--coordinator-url` for agents
+- ✅ **Binds to Tailscale IP** - Coordinator automatically accessible via Tailscale network
+- ✅ **Uses Tailscale hostnames** - Easy service discovery across your network
+- ✅ **Configures monitoring** - Prometheus automatically connects via Tailscale
+
+**Benefits:**
+- 🔒 **Secure by default** - All traffic encrypted via Tailscale
+- 🌐 **No port forwarding** - Everything works through Tailscale VPN
+- 📍 **Easy discovery** - Use hostnames instead of IPs
+- 🚀 **Simpler setup** - Just install and go!
+
+### What Gets Installed
+
+The installation script will:
+- ✅ Install Python dependencies automatically
+- ✅ Create systemd services for automatic startup
+- ✅ Set up monitoring stack (Prometheus + Grafana) for coordinator
+- ✅ Configure services to restart automatically
+- ✅ Create management commands for easy control
+- ✅ **Auto-detect and configure Tailscale** (if available)
+
+### Service Management
+
+After installation, use the `http-dispatcher` command to manage services:
+
+```bash
+# Check status
+http-dispatcher coordinator status
+http-dispatcher agent status
+http-dispatcher monitoring status
+
+# View logs
+http-dispatcher coordinator logs
+http-dispatcher agent logs
+
+# Control services
+http-dispatcher coordinator restart
+http-dispatcher agent stop
+http-dispatcher monitoring start
+```
+
+Or use standard systemd commands:
+```bash
+sudo systemctl status http-dispatcher-coordinator
+sudo systemctl restart http-dispatcher-agent
+sudo journalctl -u http-dispatcher-coordinator -f
+```
+
+## Manual Installation (Development)
+
+For development or manual setup:
 
 ```bash
 pip install -r requirements.txt
 ```
-
-## Usage
 
 ### Start the Coordinator
 

--- a/TAILSCALE.md
+++ b/TAILSCALE.md
@@ -1,0 +1,213 @@
+# Tailscale Integration Guide
+
+HTTP Dispatcher has built-in Tailscale support that makes installation and networking significantly easier!
+
+## Why Tailscale?
+
+✅ **Zero Configuration** - No port forwarding, firewall rules, or complex networking  
+✅ **Auto-Discovery** - Agents automatically find the coordinator  
+✅ **Secure by Default** - All traffic encrypted via Tailscale VPN  
+✅ **Easy Access** - Use friendly hostnames instead of IPs  
+✅ **Works Everywhere** - Same setup works on any network  
+
+## Installation with Tailscale
+
+### Coordinator Setup
+
+1. **Install Tailscale** on your coordinator server:
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   sudo tailscale up
+   ```
+
+2. **Install HTTP Dispatcher Coordinator:**
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- coordinator
+   ```
+
+   The installer will automatically:
+   - Detect your Tailscale hostname and IP
+   - Bind the coordinator to your Tailscale IP
+   - Configure monitoring to use Tailscale networking
+
+### Agent Setup
+
+1. **Install Tailscale** on each agent node:
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   sudo tailscale up
+   ```
+
+2. **Install HTTP Dispatcher Agent** (no coordinator URL needed!):
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | sudo bash -s -- agent
+   ```
+
+   The installer will:
+   - Auto-detect your coordinator by scanning Tailscale hosts
+   - Use Tailscale hostnames for connection
+   - Configure secure networking automatically
+
+## How Auto-Detection Works
+
+The installer looks for common coordinator hostnames in your Tailscale network:
+- `coordinator`
+- `http-dispatcher-coordinator`
+- `dispatcher-coordinator`
+- `server`
+- `dispatcher`
+
+If your coordinator has one of these hostnames, agents will find it automatically!
+
+## Manual Configuration
+
+If auto-detection doesn't work, you can specify the coordinator manually:
+
+```bash
+# Using Tailscale hostname
+curl -fsSL ... | sudo bash -s -- agent --coordinator-url http://my-coordinator-hostname:8000
+
+# Using Tailscale IP
+curl -fsSL ... | sudo bash -s -- agent --coordinator-url http://100.x.x.x:8000
+```
+
+## Accessing Services via Tailscale
+
+Once installed, you can access services from any Tailscale-connected device:
+
+### Coordinator API
+```bash
+# Using hostname
+curl http://coordinator-hostname:8000/api/stats
+
+# Using Tailscale IP
+curl http://100.x.x.x:8000/api/stats
+```
+
+### Monitoring Dashboards
+- **Grafana**: `http://coordinator-hostname:3000` (admin/admin)
+- **Prometheus**: `http://coordinator-hostname:9090`
+- **Metrics**: `http://coordinator-hostname:8000/metrics`
+
+## Network Configuration
+
+### Docker Containers
+
+All monitoring containers use `network_mode: host` to access Tailscale networking directly. This means:
+- Prometheus can scrape metrics via Tailscale
+- Grafana is accessible via Tailscale
+- No complex Docker networking configuration needed
+
+### Coordinator Binding
+
+The coordinator binds to:
+- `0.0.0.0:8000` - Accessible from all interfaces
+- `TAILSCALE_IP:8000` - Explicitly accessible via Tailscale
+
+This ensures the coordinator is reachable both locally and via Tailscale.
+
+## Troubleshooting
+
+### Agent Can't Find Coordinator
+
+1. **Check Tailscale status:**
+   ```bash
+   tailscale status
+   ```
+
+2. **Verify coordinator is online:**
+   ```bash
+   tailscale ping coordinator-hostname
+   ```
+
+3. **Check coordinator is running:**
+   ```bash
+   curl http://coordinator-hostname:8000/api/stats
+   ```
+
+4. **Manually specify coordinator:**
+   ```bash
+   sudo systemctl edit http-dispatcher-agent
+   # Add: Environment="DISPATCHER_COORDINATOR_URL=http://coordinator-hostname:8000"
+   sudo systemctl daemon-reload
+   sudo systemctl restart http-dispatcher-agent
+   ```
+
+### Prometheus Can't Scrape Metrics
+
+1. **Check Prometheus config:**
+   ```bash
+   cat /opt/http-dispatcher/monitoring/prometheus.yml
+   ```
+
+2. **Verify coordinator is accessible:**
+   ```bash
+   curl http://coordinator-hostname:8000/metrics
+   ```
+
+3. **Update Prometheus config if needed:**
+   ```bash
+   sudo nano /opt/http-dispatcher/monitoring/prometheus.yml
+   # Update target to use coordinator Tailscale hostname or IP
+   sudo systemctl restart http-dispatcher-monitoring
+   ```
+
+### Coordinator Not Accessible via Tailscale
+
+1. **Check Tailscale IP:**
+   ```bash
+   tailscale ip -4
+   ```
+
+2. **Verify binding:**
+   ```bash
+   sudo netstat -tlnp | grep 8000
+   ```
+
+3. **Check firewall (if any):**
+   ```bash
+   # Tailscale should handle this, but verify
+   sudo tailscale status
+   ```
+
+## Best Practices
+
+1. **Use Descriptive Hostnames** - Name your coordinator something like `http-dispatcher-coordinator` for easy discovery
+
+2. **Keep Tailscale Updated** - Regularly update Tailscale for security and performance
+
+3. **Monitor Tailscale Status** - Use `tailscale status` to verify all nodes are connected
+
+4. **Use Tailscale ACLs** - Configure access control lists for additional security
+
+5. **Backup Tailscale Keys** - Keep your Tailscale auth keys safe
+
+## Security Considerations
+
+- ✅ All traffic is encrypted via Tailscale
+- ✅ No ports need to be exposed to the internet
+- ✅ Access control via Tailscale ACLs
+- ✅ Automatic key rotation
+- ✅ Audit logs available in Tailscale admin console
+
+## Example Setup
+
+```bash
+# On coordinator server (hostname: coordinator)
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+curl -fsSL ... | sudo bash -s -- coordinator
+
+# On agent 1 (hostname: agent-1)
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+curl -fsSL ... | sudo bash -s -- agent
+
+# On agent 2 (hostname: agent-2)
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+curl -fsSL ... | sudo bash -s -- agent
+```
+
+That's it! All agents automatically connect to the coordinator via Tailscale. 🎉
+

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -6,10 +6,10 @@ services:
     image: prom/prometheus:v2.50.1
     container_name: prometheus
     ports:
-      - "100.117.91.127:9090:9090"
+      - "9090:9090"
     volumes:
-      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./monitoring/alert-rules.yml:/etc/prometheus/alert-rules.yml
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./alert-rules.yml:/etc/prometheus/alert-rules.yml
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -18,8 +18,7 @@ services:
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--storage.tsdb.retention.time=15d'
       - '--web.enable-lifecycle'
-    networks:
-      - monitoring
+    network_mode: host
     restart: unless-stopped
 
   # Grafana for dashboards
@@ -27,17 +26,16 @@ services:
     image: grafana/grafana:10.4.0
     container_name: grafana
     ports:
-      - "100.117.91.127:3000:3000"
+      - "3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
-      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/http-dispatcher-overview.json
-    networks:
-      - monitoring
+    network_mode: host
     restart: unless-stopped
     depends_on:
       - prometheus
@@ -47,7 +45,7 @@ services:
     image: prom/node-exporter:v1.7.0
     container_name: node_exporter
     ports:
-      - "100.117.91.127:9100:9100"
+      - "9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -57,8 +55,7 @@ services:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    networks:
-      - monitoring
+    network_mode: host
     restart: unless-stopped
 
   # Alertmanager for alert handling
@@ -68,21 +65,16 @@ services:
     ports:
       - "9093:9093"
     volumes:
-      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml
       - alertmanager_data:/alertmanager
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--storage.path=/alertmanager'
       - '--web.external-url=http://localhost:9093'
-    networks:
-      - monitoring
+    network_mode: host
     restart: unless-stopped
 
 volumes:
   prometheus_data:
   grafana_data:
   alertmanager_data:
-
-networks:
-  monitoring:
-    driver: bridge

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,498 @@
+#!/bin/bash
+set -e
+
+# HTTP Dispatcher Installation Script
+# Usage: curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | bash -s -- [coordinator|agent] [options]
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+MODE=""
+COORDINATOR_URL=""
+AGENT_ID=""
+INSTALL_DIR="/opt/http-dispatcher"
+SERVICE_USER="http-dispatcher"
+COORDINATOR_HOST="0.0.0.0"
+COORDINATOR_PORT="8000"
+TAILSCALE_HOSTNAME=""
+TAILSCALE_IP=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        coordinator|agent)
+            MODE="$1"
+            shift
+            ;;
+        --coordinator-url)
+            COORDINATOR_URL="$2"
+            shift 2
+            ;;
+        --agent-id)
+            AGENT_ID="$2"
+            shift 2
+            ;;
+        --host)
+            COORDINATOR_HOST="$2"
+            shift 2
+            ;;
+        --port)
+            COORDINATOR_PORT="$2"
+            shift 2
+            ;;
+        --install-dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --help)
+            echo "HTTP Dispatcher Installation Script"
+            echo ""
+            echo "Usage:"
+            echo "  curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | bash -s -- coordinator"
+            echo "  curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | bash -s -- agent [--coordinator-url URL]"
+            echo ""
+            echo "Options:"
+            echo "  coordinator              Install as coordinator"
+            echo "  agent                    Install as agent (auto-detects coordinator if Tailscale is used)"
+            echo "  --coordinator-url URL    Coordinator URL (optional if Tailscale auto-detection works)"
+            echo "  --agent-id ID            Agent ID (optional, auto-generated if not provided)"
+            echo "  --host HOST              Coordinator bind host (default: 0.0.0.0)"
+            echo "  --port PORT              Coordinator bind port (default: 8000)"
+            echo "  --install-dir DIR        Installation directory (default: /opt/http-dispatcher)"
+            echo ""
+            echo "Tailscale Integration:"
+            echo "  If Tailscale is detected, the installer will:"
+            echo "  - Auto-detect coordinator hostname for agents"
+            echo "  - Bind coordinator to Tailscale IP"
+            echo "  - Configure monitoring to use Tailscale networking"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   echo -e "${RED}This script must be run as root${NC}" 
+   echo "Please run: sudo bash -c \"\$(curl -fsSL ...)\""
+   exit 1
+fi
+
+# Tailscale detection functions
+detect_tailscale() {
+    # Check if Tailscale is installed and running
+    if command -v tailscale &> /dev/null; then
+        # Get Tailscale status
+        if tailscale status &> /dev/null; then
+            # Get Tailscale hostname
+            TAILSCALE_HOSTNAME=$(tailscale status --json 2>/dev/null | grep -o '"Name":"[^"]*"' | head -1 | cut -d'"' -f4 || echo "")
+            
+            # Get Tailscale IP (100.x.x.x)
+            TAILSCALE_IP=$(tailscale ip -4 2>/dev/null | head -1 || echo "")
+            
+            if [[ -n "$TAILSCALE_HOSTNAME" ]] || [[ -n "$TAILSCALE_IP" ]]; then
+                return 0
+            fi
+        fi
+    fi
+    return 1
+}
+
+# Determine mode if not specified
+if [[ -z "$MODE" ]]; then
+    echo -e "${YELLOW}Mode not specified. Please specify 'coordinator' or 'agent'${NC}"
+    echo "Usage: curl ... | bash -s -- coordinator"
+    exit 1
+fi
+
+# Detect Tailscale
+if detect_tailscale; then
+    echo -e "${GREEN}✓ Tailscale detected${NC}"
+    if [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+        echo -e "${BLUE}  Hostname: ${TAILSCALE_HOSTNAME}${NC}"
+    fi
+    if [[ -n "$TAILSCALE_IP" ]]; then
+        echo -e "${BLUE}  IP: ${TAILSCALE_IP}${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠ Tailscale not detected - using standard networking${NC}"
+fi
+
+# Auto-detect coordinator URL for agents if not provided
+if [[ "$MODE" == "agent" ]]; then
+    if [[ -z "$COORDINATOR_URL" ]]; then
+        # Try to auto-detect coordinator
+        if detect_tailscale && [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+            # Try common coordinator hostnames
+            COORDINATOR_CANDIDATES=("coordinator" "http-dispatcher-coordinator" "dispatcher-coordinator" "server" "dispatcher")
+            
+            # First, try to find by hostname pattern
+            for candidate in "${COORDINATOR_CANDIDATES[@]}"; do
+                if tailscale status 2>/dev/null | grep -q "$candidate"; then
+                    COORDINATOR_URL="http://${candidate}:8000"
+                    echo -e "${GREEN}✓ Auto-detected coordinator: ${COORDINATOR_URL}${NC}"
+                    break
+                fi
+            done
+            
+            # If not found, show available hosts and let user pick
+            if [[ -z "$COORDINATOR_URL" ]]; then
+                echo -e "${YELLOW}Available Tailscale hosts:${NC}"
+                tailscale status 2>/dev/null | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" | while read -r line; do
+                    hostname=$(echo "$line" | awk '{print $2}')
+                    ip=$(echo "$line" | awk '{print $1}')
+                    echo "  - $hostname ($ip)"
+                done
+                echo ""
+                echo -e "${YELLOW}Tip: Use --coordinator-url http://hostname:8000 to specify coordinator${NC}"
+            fi
+            
+            # If still not found, prompt user
+            if [[ -z "$COORDINATOR_URL" ]]; then
+                echo -e "${YELLOW}Could not auto-detect coordinator.${NC}"
+                echo -e "${YELLOW}Available Tailscale hosts:${NC}"
+                tailscale status 2>/dev/null | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" | head -5 || echo "  (none found)"
+                echo ""
+                echo -e "${RED}Error: --coordinator-url is required for agent mode${NC}"
+                echo "Example: --coordinator-url http://coordinator-hostname:8000"
+                exit 1
+            fi
+        else
+            echo -e "${RED}Error: --coordinator-url is required for agent mode${NC}"
+            echo "Example: --coordinator-url http://coordinator-ip:8000"
+            exit 1
+        fi
+    fi
+fi
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}HTTP Dispatcher Installation${NC}"
+echo -e "${BLUE}Mode: ${MODE}${NC}"
+if [[ "$MODE" == "coordinator" ]] && detect_tailscale && [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+    echo -e "${BLUE}Tailscale: ${TAILSCALE_HOSTNAME}${NC}"
+fi
+if [[ "$MODE" == "agent" ]] && [[ -n "$COORDINATOR_URL" ]]; then
+    echo -e "${BLUE}Coordinator: ${COORDINATOR_URL}${NC}"
+fi
+echo -e "${BLUE}========================================${NC}"
+
+# Detect installation method
+# If running from curl, we need to download the files
+# For now, assume we're in the project directory
+if [[ -f "main.py" ]] && [[ -d "src" ]]; then
+    echo -e "${GREEN}Detected local installation from source${NC}"
+    SOURCE_DIR="$(pwd)"
+else
+    echo -e "${RED}Error: Installation files not found in current directory${NC}"
+    echo "Please run this script from the http-dispatcher project directory"
+    echo "Or use: curl -fsSL https://raw.githubusercontent.com/your-repo/http-dispatcher/main/install.sh | bash -s -- [mode]"
+    exit 1
+fi
+
+# Create installation directory
+echo -e "${BLUE}Creating installation directory: ${INSTALL_DIR}${NC}"
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"/{bin,etc,lib,monitoring}
+
+# Copy application files
+echo -e "${BLUE}Copying application files...${NC}"
+cp -r "$SOURCE_DIR"/src "$INSTALL_DIR"/lib/
+cp "$SOURCE_DIR"/main.py "$INSTALL_DIR"/bin/
+cp "$SOURCE_DIR"/requirements.txt "$INSTALL_DIR"/
+
+# Copy monitoring files if coordinator
+if [[ "$MODE" == "coordinator" ]]; then
+    if [[ -d "$SOURCE_DIR/monitoring" ]]; then
+        cp -r "$SOURCE_DIR"/monitoring "$INSTALL_DIR"/
+    fi
+    if [[ -f "$SOURCE_DIR/docker-compose.monitoring.yml" ]]; then
+        cp "$SOURCE_DIR"/docker-compose.monitoring.yml "$INSTALL_DIR"/monitoring/
+    fi
+    
+    # Update Prometheus config with Tailscale IP if available
+    if detect_tailscale && [[ -n "$TAILSCALE_IP" ]]; then
+        echo -e "${BLUE}Updating Prometheus config with Tailscale IP: ${TAILSCALE_IP}${NC}"
+        sed -i.bak "s|host.docker.internal:8000|${TAILSCALE_IP}:${COORDINATOR_PORT}|g" "$INSTALL_DIR/monitoring/prometheus.yml"
+        rm -f "$INSTALL_DIR/monitoring/prometheus.yml.bak"
+    elif detect_tailscale && [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+        echo -e "${BLUE}Updating Prometheus config with Tailscale hostname: ${TAILSCALE_HOSTNAME}${NC}"
+        sed -i.bak "s|host.docker.internal:8000|${TAILSCALE_HOSTNAME}:${COORDINATOR_PORT}|g" "$INSTALL_DIR/monitoring/prometheus.yml"
+        rm -f "$INSTALL_DIR/monitoring/prometheus.yml.bak"
+    fi
+fi
+
+# Check for Python 3
+echo -e "${BLUE}Checking Python 3 installation...${NC}"
+if ! command -v python3 &> /dev/null; then
+    echo -e "${RED}Python 3 is not installed. Please install Python 3.8+ first.${NC}"
+    exit 1
+fi
+
+PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+echo -e "${GREEN}Found Python ${PYTHON_VERSION}${NC}"
+
+# Install Python dependencies
+echo -e "${BLUE}Installing Python dependencies...${NC}"
+python3 -m pip install --upgrade pip --quiet
+python3 -m pip install -r "$INSTALL_DIR"/requirements.txt --quiet
+
+# Create service user
+if ! id "$SERVICE_USER" &>/dev/null; then
+    echo -e "${BLUE}Creating service user: ${SERVICE_USER}${NC}"
+    useradd -r -s /bin/false -d "$INSTALL_DIR" "$SERVICE_USER"
+fi
+
+# Set ownership
+chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
+
+# Create systemd service file
+echo -e "${BLUE}Creating systemd service...${NC}"
+if [[ "$MODE" == "coordinator" ]]; then
+    # If Tailscale is available, bind to both 0.0.0.0 and Tailscale IP
+    BIND_ARGS="--host $COORDINATOR_HOST --port $COORDINATOR_PORT"
+    if detect_tailscale && [[ -n "$TAILSCALE_IP" ]]; then
+        echo -e "${GREEN}✓ Binding coordinator to Tailscale IP: ${TAILSCALE_IP}${NC}"
+        BIND_ARGS="$BIND_ARGS --bind ${TAILSCALE_IP}:${COORDINATOR_PORT}"
+    fi
+    
+    cat > /etc/systemd/system/http-dispatcher-coordinator.service <<EOF
+[Unit]
+Description=HTTP Dispatcher Coordinator
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$INSTALL_DIR
+Environment="PATH=$INSTALL_DIR/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/bin/python3 $INSTALL_DIR/bin/main.py --mode coordinator $BIND_ARGS
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    SERVICE_NAME="http-dispatcher-coordinator"
+else
+    # Generate agent ID if not provided
+    if [[ -z "$AGENT_ID" ]]; then
+        AGENT_ID="agent-$(hostname)-$(date +%s)"
+    fi
+    
+    cat > /etc/systemd/system/http-dispatcher-agent.service <<EOF
+[Unit]
+Description=HTTP Dispatcher Agent
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$INSTALL_DIR
+Environment="PATH=$INSTALL_DIR/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="DISPATCHER_COORDINATOR_URL=$COORDINATOR_URL"
+Environment="DISPATCHER_AGENT_ID=$AGENT_ID"
+ExecStart=/usr/bin/python3 $INSTALL_DIR/bin/main.py --mode agent --coordinator-url $COORDINATOR_URL --agent-id $AGENT_ID
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    SERVICE_NAME="http-dispatcher-agent"
+fi
+
+# Create monitoring service for coordinator
+if [[ "$MODE" == "coordinator" ]]; then
+    echo -e "${BLUE}Creating monitoring service...${NC}"
+    
+    # Check if docker is installed
+    if ! command -v docker &> /dev/null; then
+        echo -e "${YELLOW}Docker is not installed. Installing Docker...${NC}"
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sh get-docker.sh
+        rm get-docker.sh
+    fi
+    
+    # Check if docker-compose is installed
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        echo -e "${YELLOW}Docker Compose is not installed. Installing...${NC}"
+        # Install docker-compose v2 (docker compose)
+        if ! docker compose version &> /dev/null; then
+            # Fallback to docker-compose v1
+            curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+        fi
+    fi
+    
+    # Use docker compose (v2) if available, otherwise docker-compose (v1)
+    DOCKER_COMPOSE_CMD="docker compose"
+    if ! docker compose version &> /dev/null 2>&1; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    fi
+    
+    cat > /etc/systemd/system/http-dispatcher-monitoring.service <<EOF
+[Unit]
+Description=HTTP Dispatcher Monitoring Stack
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=$INSTALL_DIR/monitoring
+ExecStart=/bin/bash -c "$DOCKER_COMPOSE_CMD -f $INSTALL_DIR/monitoring/docker-compose.monitoring.yml up -d"
+ExecStop=/bin/bash -c "$DOCKER_COMPOSE_CMD -f $INSTALL_DIR/monitoring/docker-compose.monitoring.yml down"
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+fi
+
+# Create management script
+echo -e "${BLUE}Creating management script...${NC}"
+cat > /usr/local/bin/http-dispatcher <<'SCRIPT_EOF'
+#!/bin/bash
+SERVICE_NAME="$1"
+ACTION="$2"
+
+if [[ -z "$SERVICE_NAME" ]] || [[ -z "$ACTION" ]]; then
+    echo "Usage: http-dispatcher {coordinator|agent|monitoring} {start|stop|restart|status|logs|enable|disable}"
+    exit 1
+fi
+
+case "$SERVICE_NAME" in
+    coordinator)
+        SERVICE="http-dispatcher-coordinator"
+        ;;
+    agent)
+        SERVICE="http-dispatcher-agent"
+        ;;
+    monitoring)
+        SERVICE="http-dispatcher-monitoring"
+        ;;
+    *)
+        echo "Unknown service: $SERVICE_NAME"
+        exit 1
+        ;;
+esac
+
+case "$ACTION" in
+    start)
+        sudo systemctl start "$SERVICE"
+        ;;
+    stop)
+        sudo systemctl stop "$SERVICE"
+        ;;
+    restart)
+        sudo systemctl restart "$SERVICE"
+        ;;
+    status)
+        sudo systemctl status "$SERVICE"
+        ;;
+    logs)
+        sudo journalctl -u "$SERVICE" -f
+        ;;
+    enable)
+        sudo systemctl enable "$SERVICE"
+        ;;
+    disable)
+        sudo systemctl disable "$SERVICE"
+        ;;
+    *)
+        echo "Unknown action: $ACTION"
+        exit 1
+        ;;
+esac
+SCRIPT_EOF
+
+chmod +x /usr/local/bin/http-dispatcher
+
+# Reload systemd
+systemctl daemon-reload
+
+# Enable and start services
+echo -e "${BLUE}Enabling and starting services...${NC}"
+systemctl enable "$SERVICE_NAME"
+systemctl start "$SERVICE_NAME"
+
+if [[ "$MODE" == "coordinator" ]]; then
+    systemctl enable http-dispatcher-monitoring
+    systemctl start http-dispatcher-monitoring
+fi
+
+# Wait a moment for services to start
+sleep 2
+
+# Check service status
+if systemctl is-active --quiet "$SERVICE_NAME"; then
+    echo -e "${GREEN}✓ Service $SERVICE_NAME is running${NC}"
+else
+    echo -e "${RED}✗ Service $SERVICE_NAME failed to start${NC}"
+    echo "Check logs with: journalctl -u $SERVICE_NAME"
+    exit 1
+fi
+
+if [[ "$MODE" == "coordinator" ]]; then
+    if systemctl is-active --quiet http-dispatcher-monitoring; then
+        echo -e "${GREEN}✓ Monitoring service is running${NC}"
+    else
+        echo -e "${YELLOW}⚠ Monitoring service may need a moment to start${NC}"
+    fi
+fi
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Installation Complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "Service Management:"
+echo "  http-dispatcher $MODE status    - Check service status"
+echo "  http-dispatcher $MODE logs       - View service logs"
+echo "  http-dispatcher $MODE restart    - Restart service"
+echo ""
+
+if [[ "$MODE" == "coordinator" ]]; then
+    echo "Monitoring:"
+    echo "  http-dispatcher monitoring status  - Check monitoring status"
+    echo "  http-dispatcher monitoring logs    - View monitoring logs"
+    echo ""
+    echo "Access Points:"
+    if detect_tailscale && [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+        echo "  Coordinator API: http://$TAILSCALE_HOSTNAME:$COORDINATOR_PORT (Tailscale)"
+        echo "  Metrics: http://$TAILSCALE_HOSTNAME:$COORDINATOR_PORT/metrics (Tailscale)"
+        if [[ -n "$TAILSCALE_IP" ]]; then
+            echo "  Coordinator API: http://$TAILSCALE_IP:$COORDINATOR_PORT (Tailscale IP)"
+        fi
+    else
+        echo "  Coordinator API: http://$COORDINATOR_HOST:$COORDINATOR_PORT"
+        echo "  Metrics: http://$COORDINATOR_HOST:$COORDINATOR_PORT/metrics"
+    fi
+    echo "  Grafana: http://localhost:3000 (admin/admin)"
+    echo "  Prometheus: http://localhost:9090"
+    echo ""
+fi
+
+if [[ "$MODE" == "agent" ]]; then
+    echo "Agent Configuration:"
+    echo "  Agent ID: $AGENT_ID"
+    echo "  Coordinator: $COORDINATOR_URL"
+    if detect_tailscale && [[ -n "$TAILSCALE_HOSTNAME" ]]; then
+        echo "  Tailscale: $TAILSCALE_HOSTNAME"
+    fi
+    echo ""
+fi
+

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -13,9 +13,10 @@ rule_files:
 
 scrape_configs:
   # HTTP Dispatcher Coordinator (running on host)
+  # Note: This will be automatically updated during installation if Tailscale is detected
   - job_name: 'http-dispatcher'
     static_configs:
-      - targets: ['100.117.91.127:7575']
+      - targets: ['localhost:8000']
     metrics_path: '/metrics'
     scrape_interval: 10s
 

--- a/systemd/http-dispatcher-agent.service
+++ b/systemd/http-dispatcher-agent.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=HTTP Dispatcher Agent
+After=network.target
+
+[Service]
+Type=simple
+User=http-dispatcher
+WorkingDirectory=/opt/http-dispatcher
+Environment="PATH=/opt/http-dispatcher/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="DISPATCHER_COORDINATOR_URL=http://localhost:8000"
+Environment="DISPATCHER_AGENT_ID=agent-1"
+ExecStart=/usr/bin/python3 /opt/http-dispatcher/bin/main.py --mode agent --coordinator-url %i --agent-id %i
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+

--- a/systemd/http-dispatcher-coordinator.service
+++ b/systemd/http-dispatcher-coordinator.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=HTTP Dispatcher Coordinator
+After=network.target
+
+[Service]
+Type=simple
+User=http-dispatcher
+WorkingDirectory=/opt/http-dispatcher
+Environment="PATH=/opt/http-dispatcher/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/bin/python3 /opt/http-dispatcher/bin/main.py --mode coordinator --host 0.0.0.0 --port 8000
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+

--- a/systemd/http-dispatcher-monitoring.service
+++ b/systemd/http-dispatcher-monitoring.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=HTTP Dispatcher Monitoring Stack
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/http-dispatcher/monitoring
+ExecStart=/bin/bash -c "cd /opt/http-dispatcher/monitoring && docker compose -f docker-compose.monitoring.yml up -d || docker-compose -f docker-compose.monitoring.yml up -d"
+ExecStop=/bin/bash -c "cd /opt/http-dispatcher/monitoring && docker compose -f docker-compose.monitoring.yml down || docker-compose -f docker-compose.monitoring.yml down"
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
- Add one-liner installation script (install.sh) with curl support
- Integrate Tailscale auto-detection and coordinator discovery
- Create systemd services for coordinator, agent, and monitoring
- Add service management script (http-dispatcher command)
- Update docker-compose to use host networking for Tailscale
- Auto-configure Prometheus with Tailscale IP/hostname
- Simplify agent installation with auto-detected coordinator URL
- Add comprehensive documentation (INSTALL.md, QUICKSTART.md, TAILSCALE.md)
- Update README with Tailscale integration highlights

Key features:
- Zero-configuration agent installation with Tailscale
- Automatic coordinator discovery
- Secure networking via Tailscale VPN
- Production-ready systemd service management
- Integrated monitoring stack setup